### PR TITLE
Looks like a hyphen is missing from the breakword attribute

### DIFF
--- a/scss/_typeplate.scss
+++ b/scss/_typeplate.scss
@@ -259,7 +259,7 @@ $stats-border-style: 0.125rem solid #ccc;
 // arbitrary points if there are no otherwise acceptable break points in the line.
 
 %breakword {
-	word-wrap: breakword;
+	word-wrap: break-word;
 }
 
 %normal-wrap {


### PR DESCRIPTION
`word-wrap: breakword` doesn't resolve correctly (in Chrome at least), and in any case there should be a hyphen splitting the word into `break-word`.
