### PR TITLE
User-defined scales

### DIFF
--- a/scss/_typeplate.scss
+++ b/scss/_typeplate.scss
@@ -69,28 +69,91 @@ $amp-font-family: Verdana, sans-serif;
 // $T y p e  S c a l e
 // --------------------------------------------------------------------------
 
-// Set the multiplier value of each step of the scale.
-// The given values are those offered by default in typeplate.
-$tera-scale: 6.5;
-$giga-scale: 5;
-$mega-scale: 4;
-$alpha-scale: 3.3333;
-$beta-scale: 2.6667;
-$gamma-scale: 2;
-$delta-scale: 1.3333;
-$epsilon-scale: 1.1667;
-$zeta-scale: 1;
+// Sets a diatonic-scale from a starting point
+// the zeta value is assigned to the starting point
+// and the scales is built onwards from that
+// all the way to tera
+@function eldruz-diatonic-scale-next-step($value) {
+  @if $value < 12 { @return $value + 1; } 
+  @else if $value < 18 { @return $value + 2; }
+  @else if $value < 24 { @return $value + 3; }
+  @else { @return $value + 12; } 
+}
 
-// Apply the scale factors to the font-base size
-$tera: $font-base * $tera-scale;		//	117	= 18 × 6.5
-$giga: $font-base * $giga-scale;		//	90  = 18 × 5
-$mega: $font-base * $mega-scale;		//	72  = 18 × 4
-$alpha: $font-base * $alpha-scale;		//	60  = 18 × 3.3333
-$beta: $font-base * $beta-scale;		//	48  = 18 × 2.6667
-$gamma: $font-base * $gamma-scale;		//	36  = 18 × 2
-$delta: $font-base * $delta-scale;		//	24  = 18 × 1.3333
-$epsilon: $font-base * $epsilon-scale;	//	21  = 18 × 1.1667
-$zeta: $font-base * $zeta-scale; 		//	18  = 18 × 1
+@function eldruz-diatonic-scale-list($starting-value) {
+  // init
+  // we append the starting value of the scale to the first
+  // position in the list
+  $value: $starting-value;
+  $list-of-values: ();
+  $list-of-values: append($list-of-values, $value);
+ 
+  // for each step, we append to the list the nect value
+  // in the diatonic scale, computed by the previous value
+  @for $i from 1 through 8 {
+    $list-of-values: append($list-of-values, eldruz-diatonic-scale-next-step(nth($list-of-values, $i)));
+  }
+
+  // we return the list
+  @return $list-of-values;
+}
+
+// Apply the scale ratios in the $scale list to a starting point
+// and return a list of sizes ordered from zeta to tera
+@function eldruz-apply-scale($starting-value, $scale) {
+  $list-of-values: ();
+  @for $i from 1 through 9 {
+    $list-of-values: append($list-of-values, $starting-value * nth($scale, $i));
+  }
+
+  @return $list-of-values;
+}
+
+// USAGE
+// Users need to provide a list of 9 elements ordered from
+// zeta to tera, with the values in pixel of the different
+// sizes of the scale in the variable named $values_list.
+//
+// example :
+// $values_list: ( 18 20 22 24 32 64 72 92 124 );
+// will result in $zeta=18, $epsilon=20 and so on...
+//
+// This list can be provided thanks to a user-defined function
+// As an example, I provide the eldruz-diatonic-scale function
+// that returns a hierarchy in accordance with the typographic
+// diatonic scale with some crude calculations.
+//
+// example :
+// $values_list: eldruz-diatonic-scale(18);
+// will result in the following list :
+//   ( 18 21 24 36 48 60 72 84 96 )
+//
+// Alternatively, users can provide a list of 9 scale values
+// and apply the eldruz-apply-scale function to get the corresponding
+// list of values.
+//
+// example :
+// $typeplate-scale: ( 1 1.1667 1.3333 2 2.6667 3.3333 4 5 6.5 );
+// $values-list: eldruz-apply-scale(18, $typeplate-scale);
+// will result in the following list :
+//   ( 18 21 24 36 48 60 72 90 117 )
+//
+// As the last example is the scale provided by default by typeplate
+// I left it as is.
+
+// $values-list: eldruz-diatonic-scale-list($font-base);
+$typeplate-scale: ( 1 1.1667 1.3333 2 2.6667 3.3333 4 5 6.5 );
+$values-list: eldruz-apply-scale($font-base, $typeplate-scale);
+
+$zeta: round(nth($values_list, 1));
+$epsilon: round(nth($values_list, 2));
+$delta: round(nth($values_list, 3));
+$gamma: round(nth($values_list, 4));
+$beta: round(nth($values_list, 5));
+$alpha: round(nth($values_list, 6));
+$mega: round(nth($values_list, 7));
+$giga: round(nth($values_list, 8));
+$tera: round(nth($values_list, 9));
 
 
 // $T y p e  S c a l e  U n i t


### PR DESCRIPTION
Hi there,

First of all thanks guys for typeplate, I used it to setup my blog and it has been a breeze to use. The only thing that made me tickle is the absence of support for user-defined scales, as typeplate hard-coded its own scale from the base value of 18 pixels, which made experimenting with different scales tedious.

So I changed how the $zeta through $tera values are defined. They now take their values from a list, which is called $values_list. To change the scale, you just have to change the list. I provided a function which returns a list computed from the diatonic scale as an example. I also built a helper function which applies a scale, which is defined as a list of multipliers, to a base value and constructs the $values_list. I replicated the scale you provided as the default value. So now, users can define several scales and easily switch between them to see the effect the scales have on their design.

Everything I just said is commented in the code, along with some examples. I prefixed every function name with "eldruz" for clarity. Let me now if you found this useful, or if you have any questions at all.

Andrés, aka eldruz.

P.S.: you can safely ignore the first commit (hashed '4ebeb4d'), I should have deleted it really.
