### PR TITLE
Fixed problems with comments in template.styl that prevented compilation.

### DIFF
--- a/stylus/typeplate.styl
+++ b/stylus/typeplate.styl
@@ -548,7 +548,7 @@ h6
 
 // $Blockquote Cites
 // -------------------------------------//
-*
+/*
  * Blockquote Markup
  *
     <blockquote cite="">
@@ -627,7 +627,7 @@ pull-quotes($font-size, $opacity)
  */
 
 
- // $Footnotes
+// $Footnotes
 // -------------------------------------//
 /*
  * Footnote Markup : Replace 'X' with your unique number for each footnote


### PR DESCRIPTION
Typeplate.styl would not compile because one block comment was missing its leading slash and another was indented one space. This fixes that.
