### PR TITLE
fix: ndash -> proper ascii dash, in pull-quote example

### DIFF
--- a/templates/content/pull-quotes.html
+++ b/templates/content/pull-quotes.html
@@ -16,7 +16,7 @@
 
 	<figure class="typeplate-code-block">
 		<figcaption>HTML</figcaption>
-		<pre><code class="language-markup">&lt;aside class=&quot;typl8&ndash;pull&ndash;quote&quot;&gt;
+		<pre><code class="language-markup">&lt;aside class=&quot;typl8-pull-quote&quot;&gt;
 	&lt;blockquote&gt;
 		&lt;p&gt;&lt;/p&gt;
 	&lt;/blockquote&gt;


### PR DESCRIPTION
When copy-pasted, the example is broken: the class
    typl8-pull-quote
is displayed as
    typl8–pull–quote
making have a different name.
(unlike the other examples that use the correct symbol)